### PR TITLE
Add 3 new file output features and handle error when no data returned from Dehashed API

### DIFF
--- a/dehashed.py
+++ b/dehashed.py
@@ -1,5 +1,4 @@
 import json
-import requests
 import argparse
 import requests
 from fake_useragent import UserAgent
@@ -8,14 +7,15 @@ from time import sleep
 import os
 import sys
 
-dehashed_api_key = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' #Hardcode API key if you so choose
-dehashed_username = 'XXXXXXXXXXXXXXXXXXX' #Hardcode email if you so choose
+dehashed_api_key = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'  # Hardcode API key if you so choose
+dehashed_username = 'XXXXXXXXXXXXXXXXXXX'  # Hardcode email if you so choose
 dehashed_default = 'dehashed'
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-a', dest='api_key', nargs='?', default=dehashed_api_key, const=dehashed_api_key,
                     help='Use your dehashed.com API key to query domain.')
-parser.add_argument('-u', action='store', nargs='?', dest='username', default=dehashed_username, const=dehashed_username,
+parser.add_argument('-u', action='store', nargs='?', dest='username', default=dehashed_username,
+                    const=dehashed_username,
                     help='Use your dehashed.com username to auth to API.')
 parser.add_argument('-d', action='store', dest='domain',
                     help='Target domain to search dehashed.com for.')
@@ -23,8 +23,15 @@ parser.add_argument('-f', action='store', dest='dehashed_data_file',
                     help='Read json data from previously saved API query.')
 parser.add_argument('-o', action='store', dest='dehashed_file', nargs='?', const=dehashed_default,
                     help='Stores all hashes and cracked passwords in files. [dehashed_*.txt]')
+parser.add_argument('-n', action='store', dest='dehashed_file_no_credentials', nargs='?', const=dehashed_default,
+                    help='Stores all hashes and cracked passwords a file. [dehashed_no_credentials.txt]')
+parser.add_argument('-l', action='store', dest='dehashed_file_list', nargs='?', const=dehashed_default,
+                    help='Stores user emails and credentials lists in files. [dehashed_users.lst.txt][dehashed_credentials.lst.txt]')
+parser.add_argument('-r', action='store', dest='dehashed_file_raw', nargs='?', const=dehashed_default,
+                    help='Stores API raw json data in a file. [dehashed_[domain].json]')
 parser.add_argument('--version', action='version', version='%(prog)s 1337.1')
 args = parser.parse_args()
+
 
 def check_api_auth_success(dehashed_json_raw):
     check_success = json.loads(dehashed_json_raw)
@@ -33,43 +40,74 @@ def check_api_auth_success(dehashed_json_raw):
     else:
         pass
 
+
 def query_dehashed_domain():
-    headers = {'Accept': 'application/json',}
+    headers = {'Accept': 'application/json', }
     params = (('query', 'domain:' + args.domain),)
     dehashed_json_raw = requests.get('https://api.dehashed.com/search',
-                            headers=headers,
-                            params=params,
-                            auth=(args.username, args.api_key)).text
+                                     headers=headers,
+                                     params=params,
+                                     auth=(args.username, args.api_key)).text
     check_api_auth_success(dehashed_json_raw)
     dehashed_json = jsonify_data(dehashed_json_raw)
+    dehashed_raw_json_file = open(args.dehashed_file + '_' + args.domain + '.json', 'w', encoding='utf-8')
+    try:
+        dehashed_raw_json_file.write(dehashed_json_raw)
+    finally:
+        dehashed_raw_json_file.close()
+
     return dehashed_json
+
 
 def jsonify_data(json_raw_data):
     json_data = json.loads(json_raw_data)
     entries = json_data['entries']
     return entries
 
+
 def filter_entries():
-    for entry in entries:
-        email = entry['email']
-        # username = entry['username']
-        password = entry['password']
-        hash = entry['hashed_password']
-        if len(password) >= 1:
-            combo = email,password
-            password_combos.append(combo)
-        elif len(hash) >= 1:
-            combo = email,hash
-            hash_combos.append(combo)
-        else:
-            pass
+    try:
+        for entry in entries:
+            email = entry['email']
+            # username = entry['username']
+            password = entry['password']
+            hash = entry['hashed_password']
+            if len(password) >= 1:
+                combo = email, password
+                password_combos.append(combo)
+            elif len(hash) >= 1:
+                combo = email, hash
+                hash_combos.append(combo)
+            elif args.dehashed_file_no_credentials and len(password) == 0 and len(hash) == 0:
+                combo = email, password, hash
+                no_credential_combos.append(combo)
+            else:
+                pass
+        for entry in entries_copy:
+            email = entry['email']
+            password = entry['password']
+            hash = entry['hashed_password']
+            user_list.add(email)
+            credential_list.add(password)
+            credential_list.add(hash)
+    except Exception as e:
+        print('Entries:')
+        print(entries)
+        sys.exit('[-] Error: No data in entries. Probably error in syntax or no data returned from API.')
+
 
 def output():
     print('[+] Cleartext Passwords {email:password}')
     bool = False
     try:
-        cracked=open(args.dehashed_file + '_cracked.txt', 'a') #These are set to false by default in case user does not want to save output to file
-        hashes=open(args.dehashed_file + '_hashes.txt', 'a')
+        cracked = open(args.dehashed_file + '_' + args.domain + '_cracked.txt',
+                       'a')  # These are set to false by default in case user does not want to save output to file
+        hashes = open(args.dehashed_file + '_' + args.domain + '_hashes.txt', 'a')
+        if args.dehashed_file_no_credentials:
+            emails = open(args.dehashed_file + '_' + args.domain + '_no_credentials.txt', 'a')
+        if args.dehashed_file_list:
+            users_list = open(args.dehashed_file + '_' + args.domain + '_users.lst.txt', 'a')
+            credentials_list = open(args.dehashed_file + '_' + args.domain + '_credentials.lst.txt', 'a')
         bool = True
     except Exception as e:
         print('[-] Did not save.')
@@ -90,6 +128,30 @@ def output():
         except Exception as e:
             pass
         print(combo_raw)
+    if args.dehashed_file_no_credentials:
+        print('\n\n[+] Emails without password and hash {email}')
+        for combo in no_credential_combos:
+            combo_raw = combo[0]
+            print(combo_raw)
+            try:
+                emails.write(combo_raw)
+                emails.write('\n')
+            except Exception as e:
+                pass
+    print('\n\n[+] Output users and credentials to lists')
+    if args.dehashed_file_list:
+        for user in user_list:
+            try:
+                users_list.write(user)
+                users_list.write('\n')
+            except Exception as e:
+                pass
+        for credential in credential_list:
+            try:
+                credentials_list.write(credential)
+                credentials_list.write('\n')
+            except Exception as e:
+                pass
     print('\n\n[+] Raw Hashes to Copy/Paste then crack >:)')
     for combo in hash_combos:
         print(combo[1])
@@ -99,12 +161,14 @@ def output():
     else:
         print('[+] Done!')
 
+
 def check_data_returned(entries):
     try:
         for x in entries:
             pass
     except TypeError:
         sys.exit('[-] No data returned. Probably error in syntax.')
+
 
 def control_flow():
     if args.dehashed_data_file:
@@ -124,9 +188,14 @@ def control_flow():
     else:
         sys.exit('[-] Missing argument, exiting.')
 
+
 if __name__ == '__main__':
     entries = control_flow()
+    entries_copy = entries
     hash_combos = []
     password_combos = []
+    no_credential_combos = []
+    user_list = set()
+    credential_list = set()
     filter_entries()
     output()


### PR DESCRIPTION
feat: add 3 new file output features and handle error when no data returned from Dehashed API

- add a -n option to output emails to a file (dehashed_no_credentials.txt) for entries that have neither a password nor a hash.
    
- add a -l option to output users (emails) and passwords into two separate files (dehashed_users.lst.txt, dehashed_credentials.lst.txt) for dictionary attack.

- add a -r option to save raw JSON data to a file [dehashed_[domain].json] from Dehahsed API.